### PR TITLE
ci: downgrade to QEMU 7.2 for cross-compile builds (from 8.2.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,6 +537,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
+          qemu: '7.2'
 
       - uses: Swatinem/rust-cache@v2
       - name: Tests run with all features (including parking_lot)
@@ -576,6 +577,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
+          qemu: '7.2'
 
       - name: Remove `parking_lot` from `full` feature
         run: sed -i '0,/parking_lot/{/parking_lot/d;}' tokio/Cargo.toml
@@ -612,6 +614,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: i686-unknown-linux-gnu
+          qemu: '7.2'
 
       - uses: Swatinem/rust-cache@v2
       - name: test tokio --all-features


### PR DESCRIPTION
## Motivation

```

2024-02-15T15:26:37.7973513Z thread 'alt_threaded_scheduler_4_threads::panic_in_block_on' panicked at tokio/tests/rt_common.rs:880:29:
2024-02-15T15:26:37.7975804Z explicit panic
2024-02-15T15:26:37.7977671Z stack backtrace:
2024-02-15T15:26:37.7979839Z qemu-aarch64: QEMU internal SIGSEGV {code=MAPERR, addr=0x20}

```

## Solution

QEMU internal SIGSEGV highlights a potential QEMU bug.  Downgrading QEMU to 7.2 for the cross-compilation builds which is reported to be more stable.
